### PR TITLE
Fixed Visor init in application.conf

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -121,7 +121,7 @@ colosseum.installer.abstract.visor.config.kairosPort = "8080"
 colosseum.installer.abstract.visor.config.reportingModule = "de.uniulm.omi.cloudiator.visor.reporting.kairos.KairosReportingModule"
 colosseum.installer.abstract.visor.config.chukwaUrl = "http://localhost:8080/chukwa"
 colosseum.installer.abstract.visor.config.jmsBroker = "tcp://localhost:61616"
-colosseum.installer.abstract.visor.init = null
+colosseum.installer.abstract.visor.init = ""
 
 # Lance download path
 colosseum.installer.abstract.lance.download = "https://oss.sonatype.org/content/repositories/snapshots/io/github/cloudiator/lance/server/0.2.0-SNAPSHOT/server-0.2.0-20171122.122528-54-jar-with-dependencies.jar"


### PR DESCRIPTION
Fixed colosseum.installer.abstract.visor.init to empty String otherwise the following code will fail:
Play.application().configuration().getString("colosseum.installer.abstract.visor.init")